### PR TITLE
More files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
+set(ENABLE_TEST true)
+
 find_package(gazebo 8.0 REQUIRED)
 include_directories(${PROJECT_SOURCE_DIR} ${GAZEBO_INCLUDE_DIRS})
 link_directories(${GAZEBO_LIBRARY_DIRS})
@@ -7,6 +9,8 @@ list(APPEND CMAKE_CXX_FLAGS "${GAZEBO_CXX_FLAGS}")
   
 add_library(collision_benchmark SHARED
   collision_benchmark/WorldLoader.cc
+  collision_benchmark/GazeboPhysicsWorld.cc
+  collision_benchmark/GazeboWorldState.cc
 )
 
 add_executable(multiple_worlds_server
@@ -22,6 +26,7 @@ if (ENABLE_TEST)
   include_directories(${GTEST_INCLUDE_DIRS})
 
   add_executable(multiple_worlds_test test/MultipleWorlds_TEST.cc)
-  target_link_libraries(multiple_worlds_test ${GTEST_BOTH_LIBRARIES})
+  target_link_libraries(multiple_worlds_test
+    collision_benchmark ${GTEST_BOTH_LIBRARIES})
   add_test(MultipleWorldsTest multiple_worlds_test)
 endif (ENABLE_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,35 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 set(ENABLE_TEST true)
+set(USE_DART true)
 
 find_package(gazebo 8.0 REQUIRED)
-include_directories(${PROJECT_SOURCE_DIR} ${GAZEBO_INCLUDE_DIRS})
-link_directories(${GAZEBO_LIBRARY_DIRS})
-list(APPEND CMAKE_CXX_FLAGS "${GAZEBO_CXX_FLAGS}")
-  
+
+# DART dependencies are not automatically exported by Gazebo cmake script,
+# need to find it separately to not get undefined references to gazebo libs
+# compiled with DART support.
+if(USE_DART)
+  find_package(DART REQUIRED)
+endif(USE_DART)
+
+
 add_library(collision_benchmark SHARED
   collision_benchmark/WorldLoader.cc
   collision_benchmark/GazeboPhysicsWorld.cc
   #collision_benchmark/GazeboWorldState.cc
 )
 
+include_directories(${PROJECT_SOURCE_DIR} ${GAZEBO_INCLUDE_DIRS} ${DART_INCLUDE_DIRS})
+link_directories(${GAZEBO_LIBRARY_DIRS})
+list(APPEND CMAKE_CXX_FLAGS "${GAZEBO_CXX_FLAGS}")
+
 add_executable(multiple_worlds_server
   collision_benchmark/multiple_worlds_server.cc)
 
-target_link_libraries(collision_benchmark ${GAZEBO_LIBRARIES} pthread)
+target_link_libraries(collision_benchmark
+  ${GAZEBO_LIBRARIES}
+  ${DART_LIBRARIES})
+
 target_link_libraries(multiple_worlds_server collision_benchmark)
 
 # testing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,8 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 set(ENABLE_TEST true)
-set(USE_DART true)
 
 find_package(gazebo 8.0 REQUIRED)
-
-# DART dependencies are not automatically exported by Gazebo cmake script,
-# need to find it separately to not get undefined references to gazebo libs
-# compiled with DART support.
-if(USE_DART)
-  find_package(DART REQUIRED)
-endif(USE_DART)
-
 
 add_library(collision_benchmark SHARED
   collision_benchmark/WorldLoader.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ list(APPEND CMAKE_CXX_FLAGS "${GAZEBO_CXX_FLAGS}")
 add_library(collision_benchmark SHARED
   collision_benchmark/WorldLoader.cc
   collision_benchmark/GazeboPhysicsWorld.cc
-  collision_benchmark/GazeboWorldState.cc
+  #collision_benchmark/GazeboWorldState.cc
 )
 
 add_executable(multiple_worlds_server

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
-set(ENABLE_TEST true)
-
 find_package(gazebo 8.0 REQUIRED)
 
 add_library(collision_benchmark SHARED
@@ -14,6 +12,8 @@ include_directories(${PROJECT_SOURCE_DIR} ${GAZEBO_INCLUDE_DIRS} ${DART_INCLUDE_
 link_directories(${GAZEBO_LIBRARY_DIRS})
 list(APPEND CMAKE_CXX_FLAGS "${GAZEBO_CXX_FLAGS}")
 
+add_custom_target(tests)
+
 add_executable(multiple_worlds_server
   collision_benchmark/multiple_worlds_server.cc)
 
@@ -23,14 +23,17 @@ target_link_libraries(collision_benchmark
 
 target_link_libraries(multiple_worlds_server collision_benchmark)
 
-# testing
-if (ENABLE_TEST)
-  enable_testing()
-  find_package(GTest REQUIRED)
-  include_directories(${GTEST_INCLUDE_DIRS})
 
-  add_executable(multiple_worlds_test test/MultipleWorlds_TEST.cc)
-  target_link_libraries(multiple_worlds_test
-    collision_benchmark ${GTEST_BOTH_LIBRARIES})
-  add_test(MultipleWorldsTest multiple_worlds_test)
-endif (ENABLE_TEST)
+#####################
+# Testing
+#####################
+
+enable_testing()
+find_package(GTest REQUIRED)
+include_directories(${GTEST_INCLUDE_DIRS})
+
+add_executable(multiple_worlds_test EXCLUDE_FROM_ALL test/MultipleWorlds_TEST.cc)
+target_link_libraries(multiple_worlds_test
+  collision_benchmark ${GTEST_BOTH_LIBRARIES})
+add_test(MultipleWorldsTest multiple_worlds_test)
+add_dependencies(tests multiple_worlds_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 find_package(gazebo 8.0 REQUIRED)
-
 include_directories(${PROJECT_SOURCE_DIR} ${GAZEBO_INCLUDE_DIRS})
 link_directories(${GAZEBO_LIBRARY_DIRS})
 list(APPEND CMAKE_CXX_FLAGS "${GAZEBO_CXX_FLAGS}")
@@ -14,4 +13,15 @@ add_executable(multiple_worlds_server
   collision_benchmark/multiple_worlds_server.cc)
 
 target_link_libraries(collision_benchmark ${GAZEBO_LIBRARIES} pthread)
-target_link_libraries(multiple_worlds_server collision_benchmark) 
+target_link_libraries(multiple_worlds_server collision_benchmark)
+
+# testing
+if (ENABLE_TEST)
+  enable_testing()
+  find_package(GTest REQUIRED)
+  include_directories(${GTEST_INCLUDE_DIRS})
+
+  add_executable(multiple_worlds_test test/MultipleWorlds_TEST.cc)
+  target_link_libraries(multiple_worlds_test ${GTEST_BOTH_LIBRARIES})
+  add_test(MultipleWorldsTest multiple_worlds_test)
+endif (ENABLE_TEST)

--- a/collision_benchmark/ContactInfo.hh
+++ b/collision_benchmark/ContactInfo.hh
@@ -10,33 +10,30 @@ namespace collision_benchmark
  * \brief Basic data for a contact point between two bodies
  * \author Jennifer Buehler
  * \date October 2016
- */    
+ */
 template<class Vector3Impl, class WrenchImpl>
 class Contact
 {
-    public: typedef Vector3Impl Vector3;
-    public: typedef WrenchImpl Wrench;
+  public: typedef Vector3Impl Vector3;
+  public: typedef WrenchImpl Wrench;
 
-     public: Contact(){}
-    private: Contact(const Contact& c):
-                position(c.position),
-                normal(c.normal),
-                wrench(c.wrench),
-                depth(c.depth) {}
-    public: virtual ~Contact();
+   public: Contact(){}
+  private: Contact(const Contact& c):
+        position(c.position),
+        normal(c.normal),
+        wrench(c.wrench),
+        depth(c.depth) {}
+  public: virtual ~Contact();
 
-    public: Vector3 position;
-    public: Vector3 normal;
-    public: Wrench wrench;
-    public: double depth;
+  public: Vector3 position;
+  public: Vector3 normal;
+  public: Wrench wrench;
+  public: double depth;
 };
-
-
-
 
 /**
  * \brief Simple summary of basic contact point information compatible with a variety of physics engines.
- * Can be derived by specific physics engine implementations to supplement information. 
+ * Can be derived by specific physics engine implementations to supplement information.
  * The purpose of this base class is to allow compare contact points between different physics
  * engines, e.g. all of the Gazebo engines vs. a brute-force contact point calculation.
  *
@@ -44,7 +41,7 @@ class Contact
  *
  * Template parameters:
  * - ContactImpl any instantiated type of collision_benchmark::Contact
- * - ModelIdImpl ID type used to identify models in the world       
+ * - ModelIdImpl ID type used to identify models in the world
  * - ModelPartIdImpl ID type to identify individual parts of a model, e.g. links
  *
  * \author Jennifer Buehler
@@ -53,27 +50,27 @@ class Contact
 template<class ContactImpl, typename ModelIdImpl, typename ModelPartIdImpl>
 class ContactInfo
 {
-    public: typedef ContactImpl Contact;
-    public: typedef typename Contact::Vector3 Vector3;
-    public: typedef ModelIdImpl ModelID;
-    public: typedef ModelPartIdImpl ModelPartID;
+  public: typedef ContactImpl Contact;
+  public: typedef typename Contact::Vector3 Vector3;
+  public: typedef ModelIdImpl ModelID;
+  public: typedef ModelPartIdImpl ModelPartID;
 
-    public: ContactInfo(){}
-    private: ContactInfo(const ContactInfo& c):
-                contacts(c.contacts),
-                model1(c.model1),
-                modelPart1(c.modelPart1),
-                model2(c.model2),
-                modelPart2(c.modelpart2){}
-    public: virtual ~ContactInfo();
+  public: ContactInfo(){}
+  private: ContactInfo(const ContactInfo& c):
+        contacts(c.contacts),
+        model1(c.model1),
+        modelPart1(c.modelPart1),
+        model2(c.model2),
+        modelPart2(c.modelpart2){}
+  public: virtual ~ContactInfo();
 
-    public: std::vector<Contact> contacts;
+  public: std::vector<Contact> contacts;
 
-    public: ModelID model1;
-    public: ModelPartID modelPart1;
-    public: ModelID model2;
-    public: ModelPartID modelPart2;
-  
+  public: ModelID model1;
+  public: ModelPartID modelPart1;
+  public: ModelID model2;
+  public: ModelPartID modelPart2;
+
 };
 
 }  // namespace

--- a/collision_benchmark/ContactInfo.hh
+++ b/collision_benchmark/ContactInfo.hh
@@ -1,0 +1,81 @@
+#ifndef COLLISION_BENCHMARK_CONTACTINFO
+#define COLLISION_BENCHMARK_CONTACTINFO
+
+#include <vector>
+
+namespace collision_benchmark
+{
+
+/**
+ * \brief Basic data for a contact point between two bodies
+ * \author Jennifer Buehler
+ * \date October 2016
+ */    
+template<class Vector3Impl, class WrenchImpl>
+class Contact
+{
+    public: typedef Vector3Impl Vector3;
+    public: typedef WrenchImpl Wrench;
+
+     public: Contact(){}
+    private: Contact(const Contact& c):
+                position(c.position),
+                normal(c.normal),
+                wrench(c.wrench),
+                depth(c.depth) {}
+    public: virtual ~Contact();
+
+    public: Vector3 position;
+    public: Vector3 normal;
+    public: Wrench wrench;
+    public: double depth;
+};
+
+
+
+
+/**
+ * \brief Simple summary of basic contact point information compatible with a variety of physics engines.
+ * Can be derived by specific physics engine implementations to supplement information. 
+ * The purpose of this base class is to allow compare contact points between different physics
+ * engines, e.g. all of the Gazebo engines vs. a brute-force contact point calculation.
+ *
+ * Each contact between two bodies may consist of several contact points.
+ *
+ * Template parameters:
+ * - ContactImpl any instantiated type of collision_benchmark::Contact
+ * - ModelIdImpl ID type used to identify models in the world       
+ * - ModelPartIdImpl ID type to identify individual parts of a model, e.g. links
+ *
+ * \author Jennifer Buehler
+ * \date October 2016
+ */
+template<class ContactImpl, typename ModelIdImpl, typename ModelPartIdImpl>
+class ContactInfo
+{
+    public: typedef ContactImpl Contact;
+    public: typedef typename Contact::Vector3 Vector3;
+    public: typedef ModelIdImpl ModelID;
+    public: typedef ModelPartIdImpl ModelPartID;
+
+    public: ContactInfo(){}
+    private: ContactInfo(const ContactInfo& c):
+                contacts(c.contacts),
+                model1(c.model1),
+                modelPart1(c.modelPart1),
+                model2(c.model2),
+                modelPart2(c.modelpart2){}
+    public: virtual ~ContactInfo();
+
+    public: std::vector<Contact> contacts;
+
+    public: ModelID model1;
+    public: ModelPartID modelPart1;
+    public: ModelID model2;
+    public: ModelPartID modelPart2;
+  
+};
+
+}  // namespace
+
+#endif  // COLLISION_BENCHMARK_CONTACTINFO

--- a/collision_benchmark/GazeboPhysicsWorld.cc
+++ b/collision_benchmark/GazeboPhysicsWorld.cc
@@ -100,7 +100,7 @@ void GazeboPhysicsWorld::Clear()
     world->ClearModels();
     // need to reset physics engine in order to stop it
     // from publishing old contact points
-    gazebo::physics::PhysicsEnginePtr physics = world->GetPhysicsEngine();
+    gazebo::physics::PhysicsEnginePtr physics = world->Physics();
     if (physics) physics->GetContactManager()->Clear();
     world->SetPaused(pauseState);
 }
@@ -178,6 +178,6 @@ GazeboPhysicsWorld::ModelPtr GazeboPhysicsWorld::GetModel(const ModelID& model) 
 
 GazeboPhysicsWorld::PhysicsEnginePtr GazeboPhysicsWorld::GetPhysicsEngine() const
 {
-  if (world) return collision_benchmark::to_std_ptr<GazeboPhysicsWorld::PhysicsEngine>(world->GetPhysicsEngine());
+  if (world) return collision_benchmark::to_std_ptr<GazeboPhysicsWorld::PhysicsEngine>(world->Physics());
   return PhysicsEnginePtr();
 }

--- a/collision_benchmark/GazeboPhysicsWorld.cc
+++ b/collision_benchmark/GazeboPhysicsWorld.cc
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2012-2016 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+/**
+ * Desc: PhysicsEngineWorld implementation for Gazebo which wraps a gazebo::physics::World object
+ * Author: Jennifer Buehler
+ * Date: May 2016
+ */
+#include <collision_benchmark/GazeboPhysicsWorld.hh>
+#include <collision_benchmark/GazeboWorldState.hh>
+#include <collision_benchmark/WorldLoader.hh>
+#include <collision_benchmark/boost_std_conversion.h>
+
+#include <gazebo/physics/physics.hh>
+//#include <gazebo/physics/PhysicsIface.hh>
+
+using collision_benchmark::GazeboPhysicsWorld;
+
+GazeboPhysicsWorld::GazeboPhysicsWorld()
+{
+  std::cout<<"Constructor GazeboPhysicsWorld"<<std::endl;
+}
+
+GazeboPhysicsWorld::~GazeboPhysicsWorld()
+{
+}
+
+bool GazeboPhysicsWorld::SupportsSDF() const
+{
+  return true;
+}
+
+GazeboPhysicsWorld::OpResult GazeboPhysicsWorld::LoadFromSDF(const sdf::ElementPtr& sdf)
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+GazeboPhysicsWorld::OpResult GazeboPhysicsWorld::LoadFromFile(const std::string& filename)
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+GazeboPhysicsWorld::OpResult GazeboPhysicsWorld::LoadFromString(const std::string& str)
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+GazeboPhysicsWorld::ModelLoadResult GazeboPhysicsWorld::AddModelFromFile(const std::string& filename)
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+GazeboPhysicsWorld::ModelLoadResult GazeboPhysicsWorld::AddModelFromString(const std::string& str)
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+GazeboPhysicsWorld::ModelLoadResult GazeboPhysicsWorld::AddModelFromSDF(const sdf::ElementPtr& sdf)
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+bool GazeboPhysicsWorld::SupportsShapes() const
+{
+  return true;
+}
+
+GazeboPhysicsWorld::ModelLoadResult GazeboPhysicsWorld::AddModelFromShape(const ShapePtr& shape, const ShapePtr * collShape)
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+std::vector<GazeboPhysicsWorld::ModelID> GazeboPhysicsWorld::GetAllModelIDs() const
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+bool GazeboPhysicsWorld::RemoveModel(const ModelID& id)
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+void GazeboPhysicsWorld::Clear()
+{
+    bool pauseState = world->IsPaused();
+    world->SetPaused(true);
+    // XXX TODO CHECK: this does not clear the lights
+    world->ClearModels();
+    // need to reset physics engine in order to stop it
+    // from publishing old contact points
+    gazebo::physics::PhysicsEnginePtr physics = world->GetPhysicsEngine();
+    if (physics) physics->GetContactManager()->Clear();
+    world->SetPaused(pauseState);
+}
+
+GazeboPhysicsWorld::WorldState GazeboPhysicsWorld::GetWorldState() const
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+GazeboPhysicsWorld::WorldState GazeboPhysicsWorld::GetWorldStateDiff(const WorldState& other) const
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+GazeboPhysicsWorld::OpResult GazeboPhysicsWorld::SetWorldState(const WorldState& state, bool isDiff)
+{
+  // XXX TODO To be added in a later PR
+  /**
+  collision_benchmark::SetWorldState(world, state);
+  return PhysicsWorldBase::SUCCESS;
+  */
+  return PhysicsWorldBase::FAILED;
+}
+
+void GazeboPhysicsWorld::Update(int steps)
+{
+  gazebo::runWorld(world,steps);
+}
+
+bool GazeboPhysicsWorld::SupportsContacts() const
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+std::vector<GazeboPhysicsWorld::ContactInfoPtr> GazeboPhysicsWorld::GetContactInfo() const
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+std::vector<GazeboPhysicsWorld::ContactInfoPtr> GazeboPhysicsWorld::GetContactInfo(const ModelID& m1, const ModelID& m2) const
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+const std::vector<GazeboPhysicsWorld::ContactPtr>& GazeboPhysicsWorld::GetContacts() const
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+const std::vector<GazeboPhysicsWorld::ContactPtr> GazeboPhysicsWorld::GetContacts(const ModelID& m1, const ModelID& m2) const
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+bool GazeboPhysicsWorld::IsAdaptor() const
+{
+  return true;
+}
+
+GazeboPhysicsWorld::RefResult GazeboPhysicsWorld::SetWorld(WorldPtr& _world)
+{
+  world = collision_benchmark::to_boost_ptr<World>(_world);
+  return GazeboPhysicsWorld::REFERENCED;
+}
+
+GazeboPhysicsWorld::WorldPtr GazeboPhysicsWorld::GetWorld() const
+{
+  return collision_benchmark::to_std_ptr<World>(world);
+}
+
+GazeboPhysicsWorld::ModelPtr GazeboPhysicsWorld::GetModel(const ModelID& model) const
+{
+  throw new gazebo::common::Exception(__FILE__,__LINE__,"Implement me");
+}
+
+GazeboPhysicsWorld::PhysicsEnginePtr GazeboPhysicsWorld::GetPhysicsEngine() const
+{
+  if (world) return collision_benchmark::to_std_ptr<GazeboPhysicsWorld::PhysicsEngine>(world->GetPhysicsEngine());
+  return PhysicsEnginePtr();
+}

--- a/collision_benchmark/GazeboPhysicsWorld.cc
+++ b/collision_benchmark/GazeboPhysicsWorld.cc
@@ -20,12 +20,11 @@
  * Date: May 2016
  */
 #include <collision_benchmark/GazeboPhysicsWorld.hh>
-#include <collision_benchmark/GazeboWorldState.hh>
+//#include <collision_benchmark/GazeboWorldState.hh>
 #include <collision_benchmark/WorldLoader.hh>
 #include <collision_benchmark/boost_std_conversion.h>
 
 #include <gazebo/physics/physics.hh>
-//#include <gazebo/physics/PhysicsIface.hh>
 
 using collision_benchmark::GazeboPhysicsWorld;
 

--- a/collision_benchmark/GazeboPhysicsWorld.hh
+++ b/collision_benchmark/GazeboPhysicsWorld.hh
@@ -1,0 +1,133 @@
+#ifndef COLLISION_BENCHMARK_GAZEBOPHYSICSWORLD
+#define COLLISION_BENCHMARK_GAZEBOPHYSICSWORLD
+
+#include <collision_benchmark/PhysicsWorld.hh>
+#include <gazebo/physics/PhysicsTypes.hh>
+#include <gazebo/physics/World.hh>
+#include <gazebo/physics/Contact.hh>
+
+
+namespace collision_benchmark
+{
+
+struct GazeboPhysicsWorldTypes
+{
+  /// ID type used to identify models in the world
+  typedef std::string ModelID;
+  /// ID type to identify individual parts of a model
+  typedef std::string ModelPartID;
+
+  /// Describes a state of the world
+  typedef gazebo::physics::WorldState WorldState;
+
+  /// Math 3D vector implementation
+  typedef gazebo::math::Vector3 Vector3;
+
+  /// Math wrench implementation
+  typedef gazebo::physics::JointWrench Wrench;
+};
+
+struct GazeboPhysicsEngineWorldTypes
+{
+  typedef gazebo::physics::Model Model;
+  typedef gazebo::physics::Contact Contact;
+  typedef gazebo::physics::PhysicsEngine PhysicsEngine;
+  typedef gazebo::physics::World World;
+};
+
+/**
+ * \brief implementation of a PhysicsEngineWorld for Gazebo. Wraps a gazebo::physics::World object.
+ *
+ * \author Jennifer Buehler
+ * \date November 2016
+ */
+class GazeboPhysicsWorld: public collision_benchmark::PhysicsEngineWorld<GazeboPhysicsWorldTypes, GazeboPhysicsEngineWorldTypes>
+{
+  protected: typedef PhysicsEngineWorld<GazeboPhysicsWorldTypes, GazeboPhysicsEngineWorldTypes> ParentClass;
+
+  public: typedef typename ParentClass::ModelID ModelID;
+  public: typedef typename ParentClass::ModelPartID ModelPartID;
+  public: typedef typename ParentClass::WorldState WorldState;
+  public: typedef typename ParentClass::ContactInfo ContactInfo;
+  public: typedef typename ParentClass::ContactInfoPtr ContactInfoPtr;
+  public: typedef typename ParentClass::Shape Shape;
+  public: typedef typename ParentClass::OpResult OpResult;
+  public: typedef typename ParentClass::RefResult RefResult;
+  public: typedef typename ParentClass::ModelLoadResult ModelLoadResult;
+
+
+  public: typedef typename ParentClass::Model Model;
+  public: typedef typename ParentClass::Contact Contact;
+  public: typedef typename ParentClass::PhysicsEngine PhysicsEngine;
+  public: typedef typename ParentClass::World World;
+  public: typedef typename ParentClass::ModelPtr ModelPtr;
+  public: typedef typename ParentClass::ContactPtr ContactPtr;
+  public: typedef typename ParentClass::PhysicsEnginePtr PhysicsEnginePtr;
+  public: typedef typename ParentClass::WorldPtr WorldPtr;
+
+  public: GazeboPhysicsWorld();
+  public: GazeboPhysicsWorld(const GazeboPhysicsWorld& w){}
+  public: virtual ~GazeboPhysicsWorld();
+
+  public: virtual bool SupportsSDF() const;
+
+  public: virtual OpResult LoadFromSDF(const sdf::ElementPtr& sdf);
+
+  public: virtual OpResult LoadFromFile(const std::string& filename);
+
+  public: virtual OpResult LoadFromString(const std::string& str);
+
+  public: virtual ModelLoadResult AddModelFromFile(const std::string& filename);
+
+  public: virtual ModelLoadResult AddModelFromString(const std::string& str);
+
+  public: virtual ModelLoadResult AddModelFromSDF(const sdf::ElementPtr& sdf);
+
+  public: virtual bool SupportsShapes() const;
+
+  public: virtual ModelLoadResult AddModelFromShape(const ShapePtr& shape, const ShapePtr * collShape=NULL);
+
+  public: virtual std::vector<ModelID> GetAllModelIDs() const;
+
+  public: virtual bool RemoveModel(const ModelID& id);
+
+  public: virtual void Clear();
+
+  public: virtual WorldState GetWorldState() const;
+
+  public: virtual WorldState GetWorldStateDiff(const WorldState& other) const;
+
+  public: virtual OpResult SetWorldState(const WorldState& state, bool isDiff);
+
+  public: virtual void Update(int steps=1);
+
+  public: virtual bool SupportsContacts() const;
+
+  public: virtual std::vector<ContactInfoPtr> GetContactInfo() const;
+
+  public: virtual std::vector<ContactInfoPtr> GetContactInfo(const ModelID& m1, const ModelID& m2) const;
+
+  public: virtual const std::vector<ContactPtr>& GetContacts() const;
+
+  public: virtual const std::vector<ContactPtr> GetContacts(const ModelID& m1, const ModelID& m2) const;
+
+  public: virtual bool IsAdaptor() const;
+
+  public: virtual RefResult SetWorld(WorldPtr& world);
+
+  public: virtual WorldPtr GetWorld() const;
+
+  public: virtual ModelPtr GetModel(const ModelID& model) const;
+
+  public: virtual PhysicsEnginePtr GetPhysicsEngine() const;
+
+  private: gazebo::physics::WorldPtr world;
+};  // class GazeboPhysicsWorld
+
+/// \def GazeboPhysicsWorldPtr
+/// \brief Boost shared pointer to a GazeboPhysicsWorld object
+typedef std::shared_ptr<GazeboPhysicsWorld> GazeboPhysicsWorldPtr;
+
+}  // namespace
+
+#endif  // COLLISION_BENCHMARK_GAZEBOPHYSICSWORLD

--- a/collision_benchmark/PhysicsWorld.hh
+++ b/collision_benchmark/PhysicsWorld.hh
@@ -1,0 +1,330 @@
+#ifndef COLLISION_BENCHMARK_PHYSICSWORLD
+#define COLLISION_BENCHMARK_PHYSICSWORLD
+/*
+ * Copyright (C) 2012-2016 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <collision_benchmark/ContactInfo.hh>
+#include <collision_benchmark/Shape.hh>
+#include <boost/shared_ptr.hpp>
+#include <sdf/sdf.hh>
+
+namespace collision_benchmark
+{
+
+/**
+ * \brief Minimal pure virtual interface for various physics world implementations
+ *
+ * This interface aims to be minimal in order to support a variety of 
+ * underlying physics engine world implementations.
+ * An "underlying implementation" can be an adaptor to, or a complete implementation
+ * of a **world used for physics engines**.
+ *
+ * If possible, all implementations should derive from the subclass PhysicsEngineWorld.
+ * This pure virtual base class only guarantees a minimal common subset of functionality between implementations.
+ *
+ * Adding and removing of models, lights, or anything part of a world *has to be*
+ * supported via the general SetWorldState(). This is to keep things fairly general in-between implementations.
+ * 
+ * \param WorldStateIMpl The WorldState can be used to retrieve all sorts of information about the world, including the 
+ * model states. Most of the functionality offered via this interface is accessible via the 
+ * world state.
+ * There is no specification on what the world state type may be, in this interface they are just needed to define the API.
+ *
+ * \author Jennifer Buehler
+ * \date October 2016
+ */
+
+template<class WorldStateImpl>
+class PhysicsWorldBase
+{
+    /// NOT_SUPPORTED: depending on the context of the function, this means
+    ///     something about what the method does is not supported (eg. file format not supported)
+    public: typedef enum _OpResult {FAILED, NOT_SUPPORTED, SUCCESS} OpResult;
+    
+    /// Describes a state of the world 
+    public: typedef WorldStateImpl WorldState;
+
+    public: PhysicsWorldBase(){}
+    public: PhysicsWorldBase(const PhysicsWorldBase& w){}
+    public: virtual ~PhysicsWorldBase(){}
+
+    /// Clears the world of all models, lights and anything else that can be
+    /// in the world implementation.
+    /// A new world can be built with SetWorldState() and/or the Add* functions.
+    public: virtual void Clear()=0;
+
+    /// Get the current state of the world
+    public: virtual WorldState GetWorldState() const=0;
+   
+    /// Gets the difference to the world state in \e other as differential state.
+    /// Which means, if the returned state is applied on the current world, it will
+    /// be in the state of \e other (this includes adding or removing of models and any
+    /// other entities in the underlying world) 
+    public: virtual WorldState GetWorldStateDiff(const WorldState& other) const=0;
+
+    /// Set the current state of the world. It can be used to *update* the state, like model poses etc.,
+    /// and also to *add and remove* models, lights, or whichever entities the underlying world supports.
+    /// A \e state can also be a "differential" state (when param \e isDiff is true)
+    /// which is applied on the *existing* world, as opposed to resetting the world to the exact state \e state.
+    /// \param isDiff if true, this state is a "diff" state which is to be applied/added onto the
+    ///         current state of the world. If false, the world is reset to *exactly* this state.
+    /// \retval NOT_SUPPORTED this combination of \e state and \e isDiff is not supported, eg.
+    ///     \e state as differential state can't be applied to the current world.
+    ///     This could happen when trying to add a model which already exists in the current state.
+    ///     In general, this value is returned when the error is about the combination of
+    ///     \e isDiff and \e state, ie. the parameters not being compatible for whichever reason.
+    /// \retval FAILED Failure for other reasons than \e NOT_SUPPORTED
+    public: virtual OpResult SetWorldState(const WorldState& state, bool isDiff)=0;
+
+    /// Does \e iter subsequent update calls to the world. **This call blocks**.
+    /// \param iter number of iterations to run the world. If 0, runs forever. 
+    public: virtual void Update(int iter=1)=0; 
+};
+
+
+
+/**
+ * \brief Pure virtual extension of PhysicsWorldBase adding functionality to load world and models and contact information.
+ *
+ * This interface can act as general interface to different physics
+ * engines worlds, e.g. all of the Gazebo-integrated engines or any other implementation
+ * (eg. "brute force"). It is designed with the aim of comparing results of the engines, e.g. contact points.
+ *
+ * If possible, all implementations of PhysicsWorld should derive from the subclass PhysicsEngineWorld.
+ * This pure virtual interface only guarantees a minimal common subset of functionality between implementations.
+ *
+ * Adding and removing of models, lights, or anything part of a world *has to be*
+ * supported via the general SetWorldState(), as well as via the Add* functions and RemoveModel().
+ *
+ * \param PhysicsWorldTypes any struct which defines the following typedefs. There is no specification
+ * on what these types may be, in this interface they are just needed to define the API.
+ * - WorldState: Describes a state of the world 
+ * - ModelID: ID type used to identify models in the world       
+ * - ModelPartID: ID type to identify individual parts of a model
+ * - Vector3: Math 3D vector implementation    
+ * - Wrench: Math wrench implementation    
+ *
+ * \author Jennifer Buehler
+ * \date October 2016
+ */
+template<class PhysicsWorldTypes>
+class PhysicsWorld: public PhysicsWorldBase<typename PhysicsWorldTypes::WorldState>
+{
+    
+    /// Describes a state of the world 
+    public: typedef typename PhysicsWorldTypes::WorldState WorldState;
+    protected: typedef PhysicsWorldBase<typename PhysicsWorldTypes::WorldState> BaseClass; 
+
+    public: typedef typename BaseClass::OpResult OpResult;
+
+    /// ID type used to identify models in the world       
+    public: typedef typename PhysicsWorldTypes::ModelID ModelID;
+    /// ID type to identify individual parts of a model
+    public: typedef typename PhysicsWorldTypes::ModelPartID ModelPartID;
+    
+    private: typedef collision_benchmark::Contact<
+                            typename PhysicsWorldTypes::Vector3,
+                            typename PhysicsWorldTypes::Wrench> Contact;
+    public: typedef collision_benchmark::ContactInfo<Contact, ModelID, ModelPartID> ContactInfo;
+    public: typedef boost::shared_ptr<ContactInfo> ContactInfoPtr;
+    
+    public: typedef collision_benchmark::Shape Shape;
+
+
+    /// Results returned for loading models        
+    public: typedef struct _ModelLoadResult
+            {
+                OpResult opResult;
+                /// on success, this will contain the ID given
+                /// to the loaded model
+                ModelID modelID;
+            } ModelLoadResult;
+
+
+    public: PhysicsWorld(){}
+    public: PhysicsWorld(const PhysicsWorld& w){}
+    public: virtual ~PhysicsWorld(){}
+
+    /// \return true if SDF related methods are supported
+    public: virtual bool SupportsSDF() const = 0;
+
+    /// Like gazebo::physics::World::Load(), loads from SDF
+    /// Some implementations may not support directly reading from SDF,
+    /// in which case an exception is thrown (see also SupportsSDF()).
+    /// \retval NOT_SUPPORTED the type of model specified in the SDF is not supported
+    /// \retval FAILED Loading failed for any other reason
+    public: virtual OpResult LoadFromSDF(const sdf::ElementPtr& sdf)=0;
+
+    /// Loads a world from a file. The format of the file has to be
+    /// supported by the implementation.
+    /// \retval NOT_SUPPORTED the file type, or the world specified within is not supported
+    /// \retval FAILED Loading failed for any other reason
+    public: virtual OpResult LoadFromFile(const std::string& filename)=0;
+    
+    /// Loads a world from a string \e str. The format of the file has to be
+    /// supported by the implementation.
+    /// \retval NOT_SUPPORTED the format of the string, or the world specified within is not supported
+    /// \retval FAILED Loading failed for any other reason
+    public: virtual OpResult LoadFromString(const std::string& str)=0;
+   
+    /// Loads a model from a file and adds it to the world
+    /// To subsequently set the pose of the model, use SetWorldState(),
+    /// or specific methods of the subclass implementation.
+    /// \retval NOT_SUPPORTED the file type, or the model specified within is not supported
+    /// \retval FAILED Loading failed for any other reason
+    public: virtual ModelLoadResult AddModelFromFile(const std::string& filename)=0;
+
+    /// Loads a model from a string and adds it to the world
+    /// To subsequently set the pose of the model, use SetWorldState(),
+    /// or specific methods of the subclass implementation.
+    /// \retval NOT_SUPPORTED the format of the string, or the model specified within is not supported
+    /// \retval FAILED Loading failed for any other reason
+    public: virtual ModelLoadResult AddModelFromString(const std::string& str)=0;
+    
+    /// Loads a model from a SDF specification and adds it to the world.
+    /// Some implementations may not support directly reading from SDF,
+    /// in which case an exception is thrown (see also SupportsSDF()).
+    /// To subsequently set the pose of the model, use SetWorldState(),
+    /// or specific methods of the subclass implementation.
+    public: virtual ModelLoadResult AddModelFromSDF(const sdf::ElementPtr& sdf)=0;
+
+    /// \return true if AddModelFromShape() is supported 
+    public: virtual bool SupportsShapes() const = 0;
+
+    /// Adds this shape to the world and converts it to whichever representation
+    /// is required in the implementation. The shape will become a model which can be identified
+    /// with \e ModelID as well.
+    /// \param shape the shape to be used for visualization (if underlying implementation supports
+    ///     separate visualization shapes), and unless \e collShape is specified, this shape
+    ///     will be used for collisions as well.
+    /// \param collShape optionally, a representation of \e shape to use for collision computation
+    /// \return in case the underlying implementation does not support shapes, this throws and 
+    ///     exception (see also SupportsShapes()). Instead, the AddModel*() methods have to be used.
+    public: virtual ModelLoadResult AddModelFromShape(const ShapePtr& shape, const ShapePtr * collShape=NULL)=0;
+
+    public: virtual std::vector<ModelID> GetAllModelIDs() const=0;
+
+    /// removes a model from the world
+    /// \retval false the model was not in the world
+    public: virtual bool RemoveModel(const ModelID& id)=0;
+
+    /// \return false if the underlying implementation does not compute contact points, true otherwise.
+    public: virtual bool SupportsContacts() const=0;
+
+    /// In the current state of the world, get all contact points between models.
+    /// The returned vector will be empty if no models collide.
+    /// This method may be less efficient than methods specific to the physics engine, because it requires
+    /// constructiong the shared data structure ContactInfo. Use this method only to compare
+    /// different implementations, and stick to the engine-specific ones in subclasses otherwise.
+    ///
+    /// Throws an exception if the underlying implementation does not support calculation
+    /// of contact points (SupportContacts() returns false).
+    public: virtual std::vector<ContactInfoPtr> GetContactInfo() const=0;
+
+    /// Works as GetContactInfo() but only returns the contact points between models \e m1 and \e m2.
+    public: virtual std::vector<ContactInfoPtr> GetContactInfo(const ModelID& m1, const ModelID& m2) const=0;
+};
+
+
+/**
+ * \brief A more engine-specific pure virtual interface of PhysicsWorld which adds a broader access to physics engine functionality
+ * 
+ * If applicable, all implementations of PhysicsWorld should derive from this class, while the base
+ * class(es) only guarantees a minimal common subset of functionality between implementations.
+ *
+ * \param PhysicsEngineWorldTypes see PhysicsWorld
+ * \param PhysicsWorlTypes has to be a struct with the following typedefs:
+ * - ModelPtr: Shared pointer type to a model
+ * - ContactPtr: Shared pointer type to the engine-specific implementation of a contact point
+ * - PhysicsEnginePtr: Shared pointer type to the underlying physics engine, if there is any
+ * - WorldPtr: Shared pointer type to underlying implementation of the world, if there is any.
+ *
+ * \author Jennifer Buehler
+ * \date October 2016
+ */
+template<class PhysicsWorldTypes, class PhysicsEngineWorldTypes>
+class PhysicsEngineWorld: public PhysicsWorld<PhysicsWorldTypes>
+{
+    protected: typedef PhysicsWorld<PhysicsWorldTypes> ParentClass;
+    public: typedef typename ParentClass::ModelID ModelID;
+    public: typedef typename ParentClass::ModelPartID ModelPartID;
+    public: typedef typename ParentClass::WorldState WorldState;
+    public: typedef typename ParentClass::ContactInfoPtr ContactInfoPtr;
+
+    public: typedef typename PhysicsEngineWorldTypes::ModelPtr ModelPtr;
+    public: typedef typename PhysicsEngineWorldTypes::ContactPtr ContactPtr;
+    public: typedef typename PhysicsEngineWorldTypes::PhysicsEnginePtr PhysicsEnginePtr;
+    public: typedef typename PhysicsEngineWorldTypes::WorldPtr WorldPtr;
+    
+    public: typedef enum _RefResult {FAILED, NOT_SUPPORTED, COPIED, REFERENCED} RefResult;
+
+    public: PhysicsEngineWorld(){}
+    public: PhysicsEngineWorld(const PhysicsEngineWorld& w){}
+    public: virtual ~PhysicsEngineWorld(){}
+
+    /// In the current state of the world, get all contact points between models.
+    /// The returned vector will be empty if no models collide.
+    /// This method is more engine-specific than GetContactInfo(), and therefore
+    /// more specific to the engine used. However for that reason this function is not
+    /// suitable to compare different contact point implementations.
+    ///
+    /// Throws an exception if the underlying implementation does not support calculation
+    /// of contact points (SupportContacts() returns false).
+    public: virtual const std::vector<ContactPtr>& GetContacts() const=0;
+
+    /// Works as GetContact() but only returns the contact points between models \e m1 and \e m2.
+    public: virtual const std::vector<ContactPtr> GetContacts(const ModelID& m1, const ModelID& m2) const=0;
+
+    /// \retval true if this is an adaptor to another world (either of type 
+    ///     \e PhysicsWorld or of \e WorldPtr). This means \e GetWorld() will
+    ///     not return a reference to this instance.
+    /// \retval false if this type is a self-contained implementation of a world.
+    public: virtual bool IsAdaptor() const = 0;
+
+    /// Set the specific underlying world. This will clear out
+    /// any possibly already loaded world.
+    /// If IsAdaptor() returns false,
+    /// the whole state of \e world will be *copied* to this world.
+    /// Otherwise, the given pointer will be used as adapted world.
+    /// \retval NOT_SUPPORTED this implementation does not support setting the
+    ///     state directly from another world. Try SetWorldState instead.
+    /// \retval COPIED if the state of \e world was copied.
+    ///     In this case, the result of GetWorld() will NOT return a pointer to \e world.
+    /// \retval REFERENCED if \e world was taken as local reference to the world.
+    ///     In this case, the result of GetWorld() will return a pointer to \e world.
+    /// \retval FAILED Error copying the state of \e world.
+    public: virtual RefResult SetWorld(WorldPtr& world) = 0;
+
+    /// Returns the underlying world, or a pointer to this instance if this is
+    /// a self-contained implementation (not an adaptor to another world).
+    /// This method only makes sense to use if it is known that this implementation
+    /// is an adaptor (IsAdaptor() returns true), *and*
+    /// the specific type is known (eg. to call specific functions on it).
+    public: virtual WorldPtr GetWorld() const = 0;
+    
+    public: virtual ModelPtr GetModel(const ModelID& model) const=0;
+
+    /// Get underlying physics engine to use for more specific tests on the
+    /// current state of the world. Returns NULL pointer type if there
+    /// is no underlying physics engine for this implementation.
+    public: virtual PhysicsEnginePtr GetPhysicsEngine() const=0;
+
+};  // class PhysicsEngineWorld
+
+}  // namespace
+
+#endif  // COLLISION_BENCHMARK_PHYSICSWORLD

--- a/collision_benchmark/PhysicsWorld.hh
+++ b/collision_benchmark/PhysicsWorld.hh
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,8 +19,10 @@
 
 #include <collision_benchmark/ContactInfo.hh>
 #include <collision_benchmark/Shape.hh>
-#include <boost/shared_ptr.hpp>
 #include <sdf/sdf.hh>
+
+#include <memory>
+// #include <boost/shared_ptr.hpp>
 
 namespace collision_benchmark
 {
@@ -28,7 +30,7 @@ namespace collision_benchmark
 /**
  * \brief Minimal pure virtual interface for various physics world implementations
  *
- * This interface aims to be minimal in order to support a variety of 
+ * This interface aims to be minimal in order to support a variety of
  * underlying physics engine world implementations.
  * An "underlying implementation" can be an adaptor to, or a complete implementation
  * of a **world used for physics engines**.
@@ -38,61 +40,60 @@ namespace collision_benchmark
  *
  * Adding and removing of models, lights, or anything part of a world *has to be*
  * supported via the general SetWorldState(). This is to keep things fairly general in-between implementations.
- * 
- * \param WorldStateIMpl The WorldState can be used to retrieve all sorts of information about the world, including the 
- * model states. Most of the functionality offered via this interface is accessible via the 
+ *
+ * \param WorldStateImpl The WorldState can be used to retrieve all sorts of information about the world, including the
+ * model states. Most of the functionality offered via this interface is accessible via the
  * world state.
  * There is no specification on what the world state type may be, in this interface they are just needed to define the API.
  *
  * \author Jennifer Buehler
  * \date October 2016
  */
-
 template<class WorldStateImpl>
 class PhysicsWorldBase
 {
-    /// NOT_SUPPORTED: depending on the context of the function, this means
-    ///     something about what the method does is not supported (eg. file format not supported)
-    public: typedef enum _OpResult {FAILED, NOT_SUPPORTED, SUCCESS} OpResult;
-    
-    /// Describes a state of the world 
-    public: typedef WorldStateImpl WorldState;
+  /// NOT_SUPPORTED: depending on the context of the function, this means
+  ///   something about what the method does is not supported (eg. file format not supported)
+  public: typedef enum _OpResult {FAILED, NOT_SUPPORTED, SUCCESS} OpResult;
 
-    public: PhysicsWorldBase(){}
-    public: PhysicsWorldBase(const PhysicsWorldBase& w){}
-    public: virtual ~PhysicsWorldBase(){}
+  /// Describes a state of the world
+  public: typedef WorldStateImpl WorldState;
 
-    /// Clears the world of all models, lights and anything else that can be
-    /// in the world implementation.
-    /// A new world can be built with SetWorldState() and/or the Add* functions.
-    public: virtual void Clear()=0;
+  public: PhysicsWorldBase(){}
+  public: PhysicsWorldBase(const PhysicsWorldBase& w){}
+  public: virtual ~PhysicsWorldBase(){}
 
-    /// Get the current state of the world
-    public: virtual WorldState GetWorldState() const=0;
-   
-    /// Gets the difference to the world state in \e other as differential state.
-    /// Which means, if the returned state is applied on the current world, it will
-    /// be in the state of \e other (this includes adding or removing of models and any
-    /// other entities in the underlying world) 
-    public: virtual WorldState GetWorldStateDiff(const WorldState& other) const=0;
+  /// Clears the world of all models, lights and anything else that can be
+  /// in the world implementation.
+  /// A new world can be built with SetWorldState() and/or the Add* functions.
+  public: virtual void Clear()=0;
 
-    /// Set the current state of the world. It can be used to *update* the state, like model poses etc.,
-    /// and also to *add and remove* models, lights, or whichever entities the underlying world supports.
-    /// A \e state can also be a "differential" state (when param \e isDiff is true)
-    /// which is applied on the *existing* world, as opposed to resetting the world to the exact state \e state.
-    /// \param isDiff if true, this state is a "diff" state which is to be applied/added onto the
-    ///         current state of the world. If false, the world is reset to *exactly* this state.
-    /// \retval NOT_SUPPORTED this combination of \e state and \e isDiff is not supported, eg.
-    ///     \e state as differential state can't be applied to the current world.
-    ///     This could happen when trying to add a model which already exists in the current state.
-    ///     In general, this value is returned when the error is about the combination of
-    ///     \e isDiff and \e state, ie. the parameters not being compatible for whichever reason.
-    /// \retval FAILED Failure for other reasons than \e NOT_SUPPORTED
-    public: virtual OpResult SetWorldState(const WorldState& state, bool isDiff)=0;
+  /// Get the current state of the world
+  public: virtual WorldState GetWorldState() const=0;
 
-    /// Does \e iter subsequent update calls to the world. **This call blocks**.
-    /// \param iter number of iterations to run the world. If 0, runs forever. 
-    public: virtual void Update(int iter=1)=0; 
+  /// Gets the difference to the world state in \e other as differential state.
+  /// Which means, if the returned state is applied on the current world, it will
+  /// be in the state of \e other (this includes adding or removing of models and any
+  /// other entities in the underlying world)
+  public: virtual WorldState GetWorldStateDiff(const WorldState& other) const=0;
+
+  /// Set the current state of the world. It can be used to *update* the state, like model poses etc.,
+  /// and also to *add and remove* models, lights, or whichever entities the underlying world supports.
+  /// A \e state can also be a "differential" state (when param \e isDiff is true)
+  /// which is applied on the *existing* world, as opposed to resetting the world to the exact state \e state.
+  /// \param isDiff if true, this state is a "diff" state which is to be applied/added onto the
+  ///     current state of the world. If false, the world is reset to *exactly* this state.
+  /// \retval NOT_SUPPORTED this combination of \e state and \e isDiff is not supported, eg.
+  ///   \e state as differential state can't be applied to the current world.
+  ///   This could happen when trying to add a model which already exists in the current state.
+  ///   In general, this value is returned when the error is about the combination of
+  ///   \e isDiff and \e state, ie. the parameters not being compatible for whichever reason.
+  /// \retval FAILED Failure for other reasons than \e NOT_SUPPORTED
+  public: virtual OpResult SetWorldState(const WorldState& state, bool isDiff)=0;
+
+  /// Does \e steps subsequent update calls to the world. **This call blocks**.
+  /// \param steps number of iterations to run the world. If 0, runs forever.
+  public: virtual void Update(int steps=1)=0;
 };
 
 
@@ -112,11 +113,11 @@ class PhysicsWorldBase
  *
  * \param PhysicsWorldTypes any struct which defines the following typedefs. There is no specification
  * on what these types may be, in this interface they are just needed to define the API.
- * - WorldState: Describes a state of the world 
- * - ModelID: ID type used to identify models in the world       
+ * - WorldState: Describes a state of the world
+ * - ModelID: ID type used to identify models in the world
  * - ModelPartID: ID type to identify individual parts of a model
- * - Vector3: Math 3D vector implementation    
- * - Wrench: Math wrench implementation    
+ * - Vector3: Math 3D vector implementation
+ * - Wrench: Math wrench implementation
  *
  * \author Jennifer Buehler
  * \date October 2016
@@ -124,134 +125,134 @@ class PhysicsWorldBase
 template<class PhysicsWorldTypes>
 class PhysicsWorld: public PhysicsWorldBase<typename PhysicsWorldTypes::WorldState>
 {
-    
-    /// Describes a state of the world 
-    public: typedef typename PhysicsWorldTypes::WorldState WorldState;
-    protected: typedef PhysicsWorldBase<typename PhysicsWorldTypes::WorldState> BaseClass; 
 
-    public: typedef typename BaseClass::OpResult OpResult;
+  /// Describes a state of the world
+  public: typedef typename PhysicsWorldTypes::WorldState WorldState;
+  protected: typedef PhysicsWorldBase<typename PhysicsWorldTypes::WorldState> BaseClass;
 
-    /// ID type used to identify models in the world       
-    public: typedef typename PhysicsWorldTypes::ModelID ModelID;
-    /// ID type to identify individual parts of a model
-    public: typedef typename PhysicsWorldTypes::ModelPartID ModelPartID;
-    
-    private: typedef collision_benchmark::Contact<
-                            typename PhysicsWorldTypes::Vector3,
-                            typename PhysicsWorldTypes::Wrench> Contact;
-    public: typedef collision_benchmark::ContactInfo<Contact, ModelID, ModelPartID> ContactInfo;
-    public: typedef boost::shared_ptr<ContactInfo> ContactInfoPtr;
-    
-    public: typedef collision_benchmark::Shape Shape;
+  public: typedef typename BaseClass::OpResult OpResult;
 
+  /// ID type used to identify models in the world
+  public: typedef typename PhysicsWorldTypes::ModelID ModelID;
+  /// ID type to identify individual parts of a model
+  public: typedef typename PhysicsWorldTypes::ModelPartID ModelPartID;
 
-    /// Results returned for loading models        
-    public: typedef struct _ModelLoadResult
-            {
-                OpResult opResult;
-                /// on success, this will contain the ID given
-                /// to the loaded model
-                ModelID modelID;
-            } ModelLoadResult;
+  private: typedef collision_benchmark::Contact<
+              typename PhysicsWorldTypes::Vector3,
+              typename PhysicsWorldTypes::Wrench> Contact;
+  public: typedef collision_benchmark::ContactInfo<Contact, ModelID, ModelPartID> ContactInfo;
+  public: typedef std::shared_ptr<ContactInfo> ContactInfoPtr;
+
+  public: typedef collision_benchmark::Shape Shape;
 
 
-    public: PhysicsWorld(){}
-    public: PhysicsWorld(const PhysicsWorld& w){}
-    public: virtual ~PhysicsWorld(){}
+  /// Results returned for loading models
+  public: typedef struct _ModelLoadResult
+      {
+        OpResult opResult;
+        /// on success, this will contain the ID given
+        /// to the loaded model
+        ModelID modelID;
+      } ModelLoadResult;
 
-    /// \return true if SDF related methods are supported
-    public: virtual bool SupportsSDF() const = 0;
 
-    /// Like gazebo::physics::World::Load(), loads from SDF
-    /// Some implementations may not support directly reading from SDF,
-    /// in which case an exception is thrown (see also SupportsSDF()).
-    /// \retval NOT_SUPPORTED the type of model specified in the SDF is not supported
-    /// \retval FAILED Loading failed for any other reason
-    public: virtual OpResult LoadFromSDF(const sdf::ElementPtr& sdf)=0;
+  public: PhysicsWorld(){}
+  public: PhysicsWorld(const PhysicsWorld& w){}
+  public: virtual ~PhysicsWorld(){}
 
-    /// Loads a world from a file. The format of the file has to be
-    /// supported by the implementation.
-    /// \retval NOT_SUPPORTED the file type, or the world specified within is not supported
-    /// \retval FAILED Loading failed for any other reason
-    public: virtual OpResult LoadFromFile(const std::string& filename)=0;
-    
-    /// Loads a world from a string \e str. The format of the file has to be
-    /// supported by the implementation.
-    /// \retval NOT_SUPPORTED the format of the string, or the world specified within is not supported
-    /// \retval FAILED Loading failed for any other reason
-    public: virtual OpResult LoadFromString(const std::string& str)=0;
-   
-    /// Loads a model from a file and adds it to the world
-    /// To subsequently set the pose of the model, use SetWorldState(),
-    /// or specific methods of the subclass implementation.
-    /// \retval NOT_SUPPORTED the file type, or the model specified within is not supported
-    /// \retval FAILED Loading failed for any other reason
-    public: virtual ModelLoadResult AddModelFromFile(const std::string& filename)=0;
+  /// \return true if SDF related methods are supported
+  public: virtual bool SupportsSDF() const = 0;
 
-    /// Loads a model from a string and adds it to the world
-    /// To subsequently set the pose of the model, use SetWorldState(),
-    /// or specific methods of the subclass implementation.
-    /// \retval NOT_SUPPORTED the format of the string, or the model specified within is not supported
-    /// \retval FAILED Loading failed for any other reason
-    public: virtual ModelLoadResult AddModelFromString(const std::string& str)=0;
-    
-    /// Loads a model from a SDF specification and adds it to the world.
-    /// Some implementations may not support directly reading from SDF,
-    /// in which case an exception is thrown (see also SupportsSDF()).
-    /// To subsequently set the pose of the model, use SetWorldState(),
-    /// or specific methods of the subclass implementation.
-    public: virtual ModelLoadResult AddModelFromSDF(const sdf::ElementPtr& sdf)=0;
+  /// Like gazebo::physics::World::Load(), loads from SDF
+  /// Some implementations may not support directly reading from SDF,
+  /// in which case an exception is thrown (see also SupportsSDF()).
+  /// \retval NOT_SUPPORTED the type of model specified in the SDF is not supported
+  /// \retval FAILED Loading failed for any other reason
+  public: virtual OpResult LoadFromSDF(const sdf::ElementPtr& sdf)=0;
 
-    /// \return true if AddModelFromShape() is supported 
-    public: virtual bool SupportsShapes() const = 0;
+  /// Loads a world from a file. The format of the file has to be
+  /// supported by the implementation.
+  /// \retval NOT_SUPPORTED the file type, or the world specified within is not supported
+  /// \retval FAILED Loading failed for any other reason
+  public: virtual OpResult LoadFromFile(const std::string& filename)=0;
 
-    /// Adds this shape to the world and converts it to whichever representation
-    /// is required in the implementation. The shape will become a model which can be identified
-    /// with \e ModelID as well.
-    /// \param shape the shape to be used for visualization (if underlying implementation supports
-    ///     separate visualization shapes), and unless \e collShape is specified, this shape
-    ///     will be used for collisions as well.
-    /// \param collShape optionally, a representation of \e shape to use for collision computation
-    /// \return in case the underlying implementation does not support shapes, this throws and 
-    ///     exception (see also SupportsShapes()). Instead, the AddModel*() methods have to be used.
-    public: virtual ModelLoadResult AddModelFromShape(const ShapePtr& shape, const ShapePtr * collShape=NULL)=0;
+  /// Loads a world from a string \e str. The format of the file has to be
+  /// supported by the implementation.
+  /// \retval NOT_SUPPORTED the format of the string, or the world specified within is not supported
+  /// \retval FAILED Loading failed for any other reason
+  public: virtual OpResult LoadFromString(const std::string& str)=0;
 
-    public: virtual std::vector<ModelID> GetAllModelIDs() const=0;
+  /// Loads a model from a file and adds it to the world
+  /// To subsequently set the pose of the model, use SetWorldState(),
+  /// or specific methods of the subclass implementation.
+  /// \retval NOT_SUPPORTED the file type, or the model specified within is not supported
+  /// \retval FAILED Loading failed for any other reason
+  public: virtual ModelLoadResult AddModelFromFile(const std::string& filename)=0;
 
-    /// removes a model from the world
-    /// \retval false the model was not in the world
-    public: virtual bool RemoveModel(const ModelID& id)=0;
+  /// Loads a model from a string and adds it to the world
+  /// To subsequently set the pose of the model, use SetWorldState(),
+  /// or specific methods of the subclass implementation.
+  /// \retval NOT_SUPPORTED the format of the string, or the model specified within is not supported
+  /// \retval FAILED Loading failed for any other reason
+  public: virtual ModelLoadResult AddModelFromString(const std::string& str)=0;
 
-    /// \return false if the underlying implementation does not compute contact points, true otherwise.
-    public: virtual bool SupportsContacts() const=0;
+  /// Loads a model from a SDF specification and adds it to the world.
+  /// Some implementations may not support directly reading from SDF,
+  /// in which case an exception is thrown (see also SupportsSDF()).
+  /// To subsequently set the pose of the model, use SetWorldState(),
+  /// or specific methods of the subclass implementation.
+  public: virtual ModelLoadResult AddModelFromSDF(const sdf::ElementPtr& sdf)=0;
 
-    /// In the current state of the world, get all contact points between models.
-    /// The returned vector will be empty if no models collide.
-    /// This method may be less efficient than methods specific to the physics engine, because it requires
-    /// constructiong the shared data structure ContactInfo. Use this method only to compare
-    /// different implementations, and stick to the engine-specific ones in subclasses otherwise.
-    ///
-    /// Throws an exception if the underlying implementation does not support calculation
-    /// of contact points (SupportContacts() returns false).
-    public: virtual std::vector<ContactInfoPtr> GetContactInfo() const=0;
+  /// \return true if AddModelFromShape() is supported
+  public: virtual bool SupportsShapes() const = 0;
 
-    /// Works as GetContactInfo() but only returns the contact points between models \e m1 and \e m2.
-    public: virtual std::vector<ContactInfoPtr> GetContactInfo(const ModelID& m1, const ModelID& m2) const=0;
+  /// Adds this shape to the world and converts it to whichever representation
+  /// is required in the implementation. The shape will become a model which can be identified
+  /// with \e ModelID as well.
+  /// \param shape the shape to be used for visualization (if underlying implementation supports
+  ///   separate visualization shapes), and unless \e collShape is specified, this shape
+  ///   will be used for collisions as well.
+  /// \param collShape optionally, a representation of \e shape to use for collision computation
+  /// \return in case the underlying implementation does not support shapes, this throws and
+  ///   exception (see also SupportsShapes()). Instead, the AddModel*() methods have to be used.
+  public: virtual ModelLoadResult AddModelFromShape(const ShapePtr& shape, const ShapePtr * collShape=NULL)=0;
+
+  public: virtual std::vector<ModelID> GetAllModelIDs() const=0;
+
+  /// removes a model from the world
+  /// \retval false the model was not in the world
+  public: virtual bool RemoveModel(const ModelID& id)=0;
+
+  /// \return false if the underlying implementation does not compute contact points, true otherwise.
+  public: virtual bool SupportsContacts() const=0;
+
+  /// In the current state of the world, get all contact points between models.
+  /// The returned vector will be empty if no models collide.
+  /// This method may be less efficient than methods specific to the physics engine, because it requires
+  /// constructiong the shared data structure ContactInfo. Use this method only to compare
+  /// different implementations, and stick to the engine-specific ones in subclasses otherwise.
+  ///
+  /// Throws an exception if the underlying implementation does not support calculation
+  /// of contact points (SupportContacts() returns false).
+  public: virtual std::vector<ContactInfoPtr> GetContactInfo() const=0;
+
+  /// Works as GetContactInfo() but only returns the contact points between models \e m1 and \e m2.
+  public: virtual std::vector<ContactInfoPtr> GetContactInfo(const ModelID& m1, const ModelID& m2) const=0;
 };
 
 
 /**
  * \brief A more engine-specific pure virtual interface of PhysicsWorld which adds a broader access to physics engine functionality
- * 
+ *
  * If applicable, all implementations of PhysicsWorld should derive from this class, while the base
  * class(es) only guarantees a minimal common subset of functionality between implementations.
  *
- * \param PhysicsEngineWorldTypes see PhysicsWorld
- * \param PhysicsWorlTypes has to be a struct with the following typedefs:
- * - ModelPtr: Shared pointer type to a model
- * - ContactPtr: Shared pointer type to the engine-specific implementation of a contact point
- * - PhysicsEnginePtr: Shared pointer type to the underlying physics engine, if there is any
- * - WorldPtr: Shared pointer type to underlying implementation of the world, if there is any.
+ * \param PhysicsWorldTypes see PhysicsWorld
+ * \param PhysicsEngineWorldTypes has to be a struct with the following typedefs:
+ * - Model: The model class type
+ * - Contact: Class for engine-specific implementation of a contact point
+ * - PhysicsEngine: Class for the physics engine, if there is any (set to void* if there is none)
+ * - World: Class type of the world, if there is any (set to void* if there is none).
  *
  * \author Jennifer Buehler
  * \date October 2016
@@ -259,69 +260,74 @@ class PhysicsWorld: public PhysicsWorldBase<typename PhysicsWorldTypes::WorldSta
 template<class PhysicsWorldTypes, class PhysicsEngineWorldTypes>
 class PhysicsEngineWorld: public PhysicsWorld<PhysicsWorldTypes>
 {
-    protected: typedef PhysicsWorld<PhysicsWorldTypes> ParentClass;
-    public: typedef typename ParentClass::ModelID ModelID;
-    public: typedef typename ParentClass::ModelPartID ModelPartID;
-    public: typedef typename ParentClass::WorldState WorldState;
-    public: typedef typename ParentClass::ContactInfoPtr ContactInfoPtr;
+  protected: typedef PhysicsWorld<PhysicsWorldTypes> ParentClass;
+  public: typedef typename ParentClass::ModelID ModelID;
+  public: typedef typename ParentClass::ModelPartID ModelPartID;
+  public: typedef typename ParentClass::WorldState WorldState;
+  public: typedef typename ParentClass::ContactInfoPtr ContactInfoPtr;
 
-    public: typedef typename PhysicsEngineWorldTypes::ModelPtr ModelPtr;
-    public: typedef typename PhysicsEngineWorldTypes::ContactPtr ContactPtr;
-    public: typedef typename PhysicsEngineWorldTypes::PhysicsEnginePtr PhysicsEnginePtr;
-    public: typedef typename PhysicsEngineWorldTypes::WorldPtr WorldPtr;
-    
-    public: typedef enum _RefResult {FAILED, NOT_SUPPORTED, COPIED, REFERENCED} RefResult;
+  public: typedef typename PhysicsEngineWorldTypes::Model Model;
+  public: typedef typename PhysicsEngineWorldTypes::Contact Contact;
+  public: typedef typename PhysicsEngineWorldTypes::PhysicsEngine PhysicsEngine;
+  public: typedef typename PhysicsEngineWorldTypes::World World;
 
-    public: PhysicsEngineWorld(){}
-    public: PhysicsEngineWorld(const PhysicsEngineWorld& w){}
-    public: virtual ~PhysicsEngineWorld(){}
+  public: typedef std::shared_ptr<Model> ModelPtr;
+  public: typedef std::shared_ptr<Contact> ContactPtr;
+  public: typedef std::shared_ptr<PhysicsEngine> PhysicsEnginePtr;
+  public: typedef std::shared_ptr<World> WorldPtr;
 
-    /// In the current state of the world, get all contact points between models.
-    /// The returned vector will be empty if no models collide.
-    /// This method is more engine-specific than GetContactInfo(), and therefore
-    /// more specific to the engine used. However for that reason this function is not
-    /// suitable to compare different contact point implementations.
-    ///
-    /// Throws an exception if the underlying implementation does not support calculation
-    /// of contact points (SupportContacts() returns false).
-    public: virtual const std::vector<ContactPtr>& GetContacts() const=0;
+  public: typedef enum _RefResult {FAILED, NOT_SUPPORTED, COPIED, REFERENCED} RefResult;
 
-    /// Works as GetContact() but only returns the contact points between models \e m1 and \e m2.
-    public: virtual const std::vector<ContactPtr> GetContacts(const ModelID& m1, const ModelID& m2) const=0;
+  public: PhysicsEngineWorld(){}
+  public: PhysicsEngineWorld(const PhysicsEngineWorld& w){}
+  public: virtual ~PhysicsEngineWorld(){}
 
-    /// \retval true if this is an adaptor to another world (either of type 
-    ///     \e PhysicsWorld or of \e WorldPtr). This means \e GetWorld() will
-    ///     not return a reference to this instance.
-    /// \retval false if this type is a self-contained implementation of a world.
-    public: virtual bool IsAdaptor() const = 0;
+  /// In the current state of the world, get all contact points between models.
+  /// The returned vector will be empty if no models collide.
+  /// This method is more engine-specific than GetContactInfo(), and therefore
+  /// more specific to the engine used. However for that reason this function is not
+  /// suitable to compare different contact point implementations.
+  ///
+  /// Throws an exception if the underlying implementation does not support calculation
+  /// of contact points (SupportContacts() returns false).
+  public: virtual const std::vector<ContactPtr>& GetContacts() const=0;
 
-    /// Set the specific underlying world. This will clear out
-    /// any possibly already loaded world.
-    /// If IsAdaptor() returns false,
-    /// the whole state of \e world will be *copied* to this world.
-    /// Otherwise, the given pointer will be used as adapted world.
-    /// \retval NOT_SUPPORTED this implementation does not support setting the
-    ///     state directly from another world. Try SetWorldState instead.
-    /// \retval COPIED if the state of \e world was copied.
-    ///     In this case, the result of GetWorld() will NOT return a pointer to \e world.
-    /// \retval REFERENCED if \e world was taken as local reference to the world.
-    ///     In this case, the result of GetWorld() will return a pointer to \e world.
-    /// \retval FAILED Error copying the state of \e world.
-    public: virtual RefResult SetWorld(WorldPtr& world) = 0;
+  /// Works as GetContact() but only returns the contact points between models \e m1 and \e m2.
+  public: virtual const std::vector<ContactPtr> GetContacts(const ModelID& m1, const ModelID& m2) const=0;
 
-    /// Returns the underlying world, or a pointer to this instance if this is
-    /// a self-contained implementation (not an adaptor to another world).
-    /// This method only makes sense to use if it is known that this implementation
-    /// is an adaptor (IsAdaptor() returns true), *and*
-    /// the specific type is known (eg. to call specific functions on it).
-    public: virtual WorldPtr GetWorld() const = 0;
-    
-    public: virtual ModelPtr GetModel(const ModelID& model) const=0;
+  /// \retval true if this is an adaptor to another world (either of type
+  ///   \e PhysicsWorld or of \e WorldPtr). This means \e GetWorld() will
+  ///   not return a reference to this instance.
+  /// \retval false if this type is a self-contained implementation of a world.
+  public: virtual bool IsAdaptor() const = 0;
 
-    /// Get underlying physics engine to use for more specific tests on the
-    /// current state of the world. Returns NULL pointer type if there
-    /// is no underlying physics engine for this implementation.
-    public: virtual PhysicsEnginePtr GetPhysicsEngine() const=0;
+  /// Set the specific underlying world. This will clear out
+  /// any possibly already loaded world.
+  /// If IsAdaptor() returns false,
+  /// the whole state of \e world will be *copied* to this world.
+  /// Otherwise, the given pointer will be used as adapted world.
+  /// \retval NOT_SUPPORTED this implementation does not support setting the
+  ///   state directly from another world. Try SetWorldState instead.
+  /// \retval COPIED if the state of \e world was copied.
+  ///   In this case, the result of GetWorld() will NOT return a pointer to \e world.
+  /// \retval REFERENCED if \e world was taken as local reference to the world.
+  ///   In this case, the result of GetWorld() will return a pointer to \e world.
+  /// \retval FAILED Error copying the state of \e world.
+  public: virtual RefResult SetWorld(WorldPtr& world) = 0;
+
+  /// Returns the underlying world, or a pointer to this instance if this is
+  /// a self-contained implementation (not an adaptor to another world).
+  /// This method only makes sense to use if it is known that this implementation
+  /// is an adaptor (IsAdaptor() returns true), *and*
+  /// the specific type is known (eg. to call specific functions on it).
+  public: virtual WorldPtr GetWorld() const = 0;
+
+  public: virtual ModelPtr GetModel(const ModelID& model) const=0;
+
+  /// Get underlying physics engine to use for more specific tests on the
+  /// current state of the world. Returns NULL pointer type if there
+  /// is no underlying physics engine for this implementation.
+  public: virtual PhysicsEnginePtr GetPhysicsEngine() const=0;
 
 };  // class PhysicsEngineWorld
 

--- a/collision_benchmark/Shape.hh
+++ b/collision_benchmark/Shape.hh
@@ -1,0 +1,27 @@
+#ifndef COLLISION_BENCHMARK_SHAPE
+#define COLLISION_BENCHMARK_SHAPE
+
+#include <boost/shared_ptr.hpp>
+
+namespace collision_benchmark
+{
+
+/**
+ * \brief Basic interface for a shape
+ * \author Jennifer Buehler
+ * \date October 2016
+ */    
+class Shape
+{
+
+    public: Shape(){}
+    private: Shape(const Shape& c){}
+    public: virtual ~Shape(){}
+
+};
+
+typedef boost::shared_ptr<Shape> ShapePtr;
+
+}  // namespace
+
+#endif  // COLLISION_BENCHMARK_SHAPE

--- a/collision_benchmark/Shape.hh
+++ b/collision_benchmark/Shape.hh
@@ -10,13 +10,13 @@ namespace collision_benchmark
  * \brief Basic interface for a shape
  * \author Jennifer Buehler
  * \date October 2016
- */    
+ */
 class Shape
 {
 
-    public: Shape(){}
-    private: Shape(const Shape& c){}
-    public: virtual ~Shape(){}
+  public: Shape(){}
+  private: Shape(const Shape& c){}
+  public: virtual ~Shape(){}
 
 };
 

--- a/collision_benchmark/WorldLoader.cc
+++ b/collision_benchmark/WorldLoader.cc
@@ -183,7 +183,7 @@ gazebo::physics::WorldPtr collision_benchmark::LoadWorld(const std::string& worl
     return gazebo::physics::WorldPtr();
   }
 
-  std::string worldNamespace = world->GetName();
+  std::string worldNamespace = world->Name();
 
   // wait for namespace to be loaded, to make sure the order of namespaces maintained
   // in the transport system eventually will correspond to the same order of the worlds

--- a/collision_benchmark/WorldLoader.cc
+++ b/collision_benchmark/WorldLoader.cc
@@ -196,11 +196,11 @@ gazebo::physics::WorldPtr collision_benchmark::LoadWorld(const std::string& worl
 }
 
 
-std::vector<gazebo::physics::WorldPtr> collision_benchmark::LoadWorlds(const std::set<Worldfile>& worldfiles)
+std::vector<gazebo::physics::WorldPtr> collision_benchmark::LoadWorlds(const std::vector<Worldfile>& worldfiles)
 {
   std::vector<gazebo::physics::WorldPtr> worlds;
   // -- load all worlds --
-  for (std::set<Worldfile>::const_iterator w = worldfiles.begin();
+  for (std::vector<Worldfile>::const_iterator w = worldfiles.begin();
       w != worldfiles.end(); ++w)
   {
     std::cout << "Loading world " << w->filename << " (named as '" << w->worldname << "')" << std::endl;

--- a/collision_benchmark/WorldLoader.hh
+++ b/collision_benchmark/WorldLoader.hh
@@ -1,6 +1,3 @@
-#ifndef COLLISION_BENCHMARK_WORLDLOADER
-#define COLLISION_BENCHMARK_WORLDLOADER
-
 /*
  * Copyright (C) 2012-2016 Open Source Robotics Foundation
  *
@@ -21,8 +18,7 @@
 #define COLLISIONBENCHMARK_WORLDLOADER_
 
 #include <gazebo/gazebo.hh>
-
-#include <set>
+#include <vector>
 
 namespace collision_benchmark
 {
@@ -59,13 +55,15 @@ class Worldfile
   public: std::string worldname;
 };
 
-/// Convenience function to load several worlds at once
+/// Convenience function to load several worlds at once. Loads the worlds in the order given in \e worldfiles
+///  and returns the accordingly in the same order.
+///
 /// \param worldNames has to be of same size as \e worldfiles and contains names
 ///        of the respective worlds to override the name given in the world file.
 ///        If a names is an empty string, it will instead keep the name in the original world
 ///        file or use the default name.
 /// \return worlds will contain the loaded worlds
-std::vector<gazebo::physics::WorldPtr> LoadWorlds(const std::set<Worldfile>& worldfiles);
+std::vector<gazebo::physics::WorldPtr> LoadWorlds(const std::vector<Worldfile>& worldfiles);
 
 }  // namespace collision_benchmark
 

--- a/collision_benchmark/WorldLoader.hh
+++ b/collision_benchmark/WorldLoader.hh
@@ -1,3 +1,6 @@
+#ifndef COLLISION_BENCHMARK_WORLDLOADER
+#define COLLISION_BENCHMARK_WORLDLOADER
+
 /*
  * Copyright (C) 2012-2016 Open Source Robotics Foundation
  *
@@ -45,3 +48,5 @@ extern bool LoadWorlds(const std::vector<std::string>& worldfiles,
                        std::vector<gazebo::physics::WorldPtr>& worlds);
 
 }  // namespace collision_benchmark
+
+#endif  // COLLISION_BENCHMARK_WORLDLOADER

--- a/collision_benchmark/boost_std_conversion.h
+++ b/collision_benchmark/boost_std_conversion.h
@@ -1,0 +1,55 @@
+#ifndef COLLISION_BENCHMARK_BOOST_STD_CONVERSION_H
+#define COLLISION_BENCHMARK_BOOST_STD_CONVERSION_H
+
+#include <algorithm>
+#include <memory>
+#include <boost/shared_ptr.hpp>
+
+namespace collision_benchmark
+{
+
+namespace
+{
+template<class SharedPointer> struct Holder
+{
+  SharedPointer p;
+
+  Holder(const SharedPointer &p) : p(p) {}
+  Holder(const Holder &other) : p(other.p) {}
+  Holder(Holder &&other) : p(std::move(other.p)) {}
+
+  void operator()(...) { p.reset(); }
+};
+}
+
+template<class T> std::shared_ptr<T> to_std_ptr(const boost::shared_ptr<T> &p)
+{
+  typedef Holder<std::shared_ptr<T>> H;
+
+  if (H *h = boost::get_deleter<H, T>(p))
+  {
+    return h->p;
+  }
+  else
+  {
+    return std::shared_ptr<T>(p.get(), Holder<boost::shared_ptr<T>>(p));
+  }
+}
+
+template<class T> boost::shared_ptr<T> to_boost_ptr(const std::shared_ptr<T> &p)
+{
+  typedef Holder<boost::shared_ptr<T>> H;
+
+  if (H *h = std::get_deleter<H, T>(p))
+  {
+    return h->p;
+  }
+  else
+  {
+    return boost::shared_ptr<T>(p.get(), Holder<std::shared_ptr<T>>(p));
+  }
+}
+
+}  // namespace
+
+#endif  // COLLISION_BENCHMARK_BOOST_STD_CONVERSION_H

--- a/collision_benchmark/multiple_worlds_server.cc
+++ b/collision_benchmark/multiple_worlds_server.cc
@@ -16,7 +16,7 @@
 */
 
 #include <collision_benchmark/WorldLoader.hh>
-#include <collision_benchmark/GazeboWorldState.hh>
+// #include <collision_benchmark/GazeboWorldState.hh> // TODO to be added in next PR
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
 
@@ -71,20 +71,21 @@ bool PlayTest(int argc, char **argv)
   }
 
   // Go through all worlds and print info
+  /* TODO: This will be added in the next PR
   bool printState = false;
   if (printState)
   {
     std::cout << "##### States of all worlds before running:" << std::endl;
     collision_benchmark::PrintWorldStates(worlds);
-  }
+  }*/
 
   RunWorlds(numIters, worlds);
 
-  if (printState)
+  /*if (printState)
   {
     std::cout << "##### States of all worlds after running:" << std::endl;
     collision_benchmark::PrintWorldStates(worlds);
-  }
+  }*/
 
   return true;
 }

--- a/collision_benchmark/multiple_worlds_server.cc
+++ b/collision_benchmark/multiple_worlds_server.cc
@@ -16,37 +16,14 @@
 */
 
 #include <collision_benchmark/WorldLoader.hh>
+#include <collision_benchmark/GazeboWorldState.hh>
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
 
-//#define WORLDSTATES_QUIET
 
-void PrintWorldState(const gazebo::physics::WorldPtr world)
-{
-  std::cout << "## State of world " << world->GetName() << std::endl;
-  gazebo::physics::WorldState _state(world);
-  std::cout << _state << std::endl;
-}
-
-void PrintWorldStates(const std::vector<gazebo::physics::WorldPtr>& worlds)
-{
-  std::cout << "## World states ###" << std::endl;
-  for (std::vector<gazebo::physics::WorldPtr>::const_iterator w = worlds.begin();
-      w != worlds.end(); ++w)
-  {
-    PrintWorldState(*w);
-  }
-  std::cout << "#####" << std::endl;
-}
-
-/// Convenience function to call gazebo::runWorld() on several worlds
+/// Convenience function to call gazebo::runWorld() on several worlds \e iter times
 void RunWorlds(int iter, const std::vector<gazebo::physics::WorldPtr>& worlds)
 {
-#ifndef WORLDSTATES_QUIET
-  std::cout << "##### States of all worlds before running:" << std::endl;
-  PrintWorldStates(worlds);
-#endif
-  int steps = 1;
   for (unsigned int i = 0; i < iter; ++i)
   {
     // std::cout << "##### Running world(s), iter=" << i << std::endl;
@@ -56,14 +33,11 @@ void RunWorlds(int iter, const std::vector<gazebo::physics::WorldPtr>& worlds)
       gazebo::physics::WorldPtr world = *w;
       std::cout<<"World "<<world->GetName()<<" physics engine: "<<world->GetPhysicsEngine()->GetType()<<std::endl;
       // Run simulation for given number of steps.
-      // This method calls world->RunBlocking(_iterations);
+      // This method calls world->RunBlocking();
+      int steps = 1;
       gazebo::runWorld(world, steps);
     }
   }
-#ifndef WORLDSTATES_QUIET
-  std::cout << "##### States of all worlds after running:" << std::endl;
-  PrintWorldStates(worlds);
-#endif
 }
 
 // Main method to play the test, later to be replaced by a dedicated structure (without command line arument params)
@@ -76,7 +50,7 @@ bool PlayTest(int argc, char **argv)
   }
 
   // list of worlds to be loaded
-  std::set<collision_benchmark::Worldfile> worldsToLoad;
+  std::vector<collision_benchmark::Worldfile> worldsToLoad;
 
   int numIters = atoi(argv[1]);
 
@@ -85,7 +59,7 @@ bool PlayTest(int argc, char **argv)
     std::string worldfile = std::string(argv[i]);
     std::stringstream worldname;
     worldname << "world_" << i - 1;
-    worldsToLoad.insert(collision_benchmark::Worldfile(worldfile,worldname.str()));
+    worldsToLoad.push_back(collision_benchmark::Worldfile(worldfile,worldname.str()));
   }
 
   std::cout << "Loading worlds..." << std::endl;
@@ -97,10 +71,21 @@ bool PlayTest(int argc, char **argv)
   }
 
   // Go through all worlds and print info
-  for (int i = 0; i < worlds.size(); ++i)
+  bool printState = false;
+  if (printState)
   {
-    RunWorlds(numIters, worlds);
+    std::cout << "##### States of all worlds before running:" << std::endl;
+    collision_benchmark::PrintWorldStates(worlds);
   }
+
+  RunWorlds(numIters, worlds);
+
+  if (printState)
+  {
+    std::cout << "##### States of all worlds after running:" << std::endl;
+    collision_benchmark::PrintWorldStates(worlds);
+  }
+
   return true;
 }
 

--- a/collision_benchmark/multiple_worlds_server.cc
+++ b/collision_benchmark/multiple_worlds_server.cc
@@ -31,7 +31,7 @@ void RunWorlds(int iter, const std::vector<gazebo::physics::WorldPtr>& worlds)
         w != worlds.end(); ++w)
     {
       gazebo::physics::WorldPtr world = *w;
-      std::cout<<"World "<<world->GetName()<<" physics engine: "<<world->GetPhysicsEngine()->GetType()<<std::endl;
+      std::cout<<"World "<<world->Name()<<" physics engine: "<<world->Physics()->GetType()<<std::endl;
       // Run simulation for given number of steps.
       // This method calls world->RunBlocking();
       int steps = 1;

--- a/test/MultipleWorlds_TEST.cc
+++ b/test/MultipleWorlds_TEST.cc
@@ -66,13 +66,13 @@ TEST_F(MultipleWorldsTest, UsesDifferentEngines)
   for (std::vector<gazebo::physics::WorldPtr>::iterator it=worlds.begin(); it!=worlds.end(); ++it)
   {
     ASSERT_NE(it->get(),nullptr) << " World NULL pointer returned";
-    ASSERT_NE((*it)->GetPhysicsEngine().get(), nullptr) << " World PhysicsEngine cannot be NULL";
+    ASSERT_NE((*it)->Physics().get(), nullptr) << " World PhysicsEngine cannot be NULL";
   }
 
   int i=0;
-  ASSERT_EQ(worlds[i++]->GetPhysicsEngine()->GetType(), "ode") << "Engine must be ODE";
-  ASSERT_EQ(worlds[i++]->GetPhysicsEngine()->GetType(), "bullet") << "Engine must be Bullet";
-  ASSERT_EQ(worlds[i++]->GetPhysicsEngine()->GetType(), "dart") << "Engine must be DART";
+  ASSERT_EQ(worlds[i++]->Physics()->GetType(), "ode") << "Engine must be ODE";
+  ASSERT_EQ(worlds[i++]->Physics()->GetType(), "bullet") << "Engine must be Bullet";
+  ASSERT_EQ(worlds[i++]->Physics()->GetType(), "dart") << "Engine must be DART";
 }
 
 TEST_F(MultipleWorldsTest, OtherTest)

--- a/test/MultipleWorlds_TEST.cc
+++ b/test/MultipleWorlds_TEST.cc
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+
+class MultipleWorldsTest : public ::testing::Test {
+  protected:
+
+  MultipleWorldsTest()
+  {
+  }
+  virtual ~MultipleWorldsTest()
+  {
+  }
+
+  virtual void SetUp()
+  {
+  }
+
+  virtual void TearDown()
+  {
+  }
+};
+
+TEST_F(MultipleWorldsTest, UsesDifferentEngines)
+{
+  int test = 1;
+  ASSERT_EQ(test,1) << "Test must be 1";
+}
+
+TEST_F(MultipleWorldsTest, OtherTest)
+{
+  int test = 2;
+  ASSERT_EQ(test,2) << "Test must be 2";
+}
+
+
+int main(int argc, char**argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/MultipleWorlds_TEST.cc
+++ b/test/MultipleWorlds_TEST.cc
@@ -1,9 +1,15 @@
 #include <gtest/gtest.h>
 
+#include <collision_benchmark/WorldLoader.hh>
+
+#include <gazebo/gazebo.hh>
+#include <gazebo/physics/physics.hh>
+
 class MultipleWorldsTest : public ::testing::Test {
   protected:
 
   MultipleWorldsTest()
+    :fakeProgramName("MultipleWorldsTest")
   {
   }
   virtual ~MultipleWorldsTest()
@@ -12,17 +18,61 @@ class MultipleWorldsTest : public ::testing::Test {
 
   virtual void SetUp()
   {
+    // irrelevant to pass fake argv, so make an exception
+    // and pass away constness, so that fakeProgramName can be
+    // initialized easily in constructor.
+    gazebo::setupServer(1, (char**)&fakeProgramName);
   }
 
   virtual void TearDown()
   {
+    gazebo::shutdown();
   }
+
+  private:
+  const char * fakeProgramName;
 };
+
+/// load all worlds from file, in the order given in \e filenames
+std::vector<gazebo::physics::WorldPtr> LoadWorlds(const std::vector<std::string>& filenames)
+{
+  // list of worlds to be loaded
+  std::vector<collision_benchmark::Worldfile> worldsToLoad;
+  int i=0;
+  for (std::vector<std::string>::const_iterator it=filenames.begin(); it!=filenames.end(); ++it, ++i)
+  {
+    std::string worldfile = *it;
+    std::stringstream worldname;
+    worldname << "world_" << i - 1;
+    worldsToLoad.push_back(collision_benchmark::Worldfile(worldfile,worldname.str()));
+  }
+  return collision_benchmark::LoadWorlds(worldsToLoad);
+}
+
 
 TEST_F(MultipleWorldsTest, UsesDifferentEngines)
 {
-  int test = 1;
-  ASSERT_EQ(test,1) << "Test must be 1";
+  std::vector<std::string> filenames;
+  filenames.push_back("../test_worlds/empty_ode.world");
+  filenames.push_back("../test_worlds/empty_bullet.world");
+  filenames.push_back("../test_worlds/empty_dart.world");
+
+  std::vector<gazebo::physics::WorldPtr> worlds=LoadWorlds(filenames);
+
+  if (worlds.size() !=3 ) std::cout<<"Worlds not loaded"<<std::endl;
+
+  ASSERT_EQ(worlds.size(), 3) << " 3 Worlds must have been loaded";
+
+  for (std::vector<gazebo::physics::WorldPtr>::iterator it=worlds.begin(); it!=worlds.end(); ++it)
+  {
+    ASSERT_NE(it->get(),nullptr) << " World NULL pointer returned";
+    ASSERT_NE((*it)->GetPhysicsEngine().get(), nullptr) << " World PhysicsEngine cannot be NULL";
+  }
+
+  int i=0;
+  ASSERT_EQ(worlds[i++]->GetPhysicsEngine()->GetType(), "ode") << "Engine must be ODE";
+  ASSERT_EQ(worlds[i++]->GetPhysicsEngine()->GetType(), "bullet") << "Engine must be Bullet";
+  ASSERT_EQ(worlds[i++]->GetPhysicsEngine()->GetType(), "dart") << "Engine must be DART";
 }
 
 TEST_F(MultipleWorldsTest, OtherTest)


### PR DESCRIPTION
This PR adds some more files required for the test framework:

- Contact information class which may be used to read contact info from various frameworks and treat them uniformly (e.g. compare contacts coming from Gazebo and from other libraries used for the testing and comparing contact points) 
- Classes ``PhysicsWorld`` and its implementation for Gazebo, ``GazeboPhysicsWorld``. The former is a general interface to the test framework, the latter an implementation for Gazebo.
- Helper to convert between boost and std shared pointers
- First test file which checks that different worlds are running different engines. This is still a bit flakey in that it doesn't first check which engines are being used with Gazebo. It assumes ode, bullet and dart are used.

